### PR TITLE
Redo Docker image. Resolves #8 Resolves #9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
-FROM       docker:latest
+FROM       alpine:3.14
 LABEL      maintainer="BlueT - Matthew Lien - 練喆明 <bluet@bluet.org>"
 
 # Docker defaults
+ENV        CRONICLE_VERSION 0.8.62
 ENV        CRONICLE_base_app_url 'http://localhost:3012'
 ENV        CRONICLE_WebServer__http_port 3012
 ENV        CRONICLE_WebServer__https_port 443
+ENV        EDITOR=nano
 
-RUN        apk add --no-cache nodejs npm git curl wget perl bash perl-pathtools tar procps tini
-# RUN        apk add --no-cache docker nodejs npm git curl wget perl bash perl-pathtools tar procps tini
-RUN        curl -s https://raw.githubusercontent.com/jhuckaby/Cronicle/master/bin/install.js | node
+RUN        apk add --no-cache nodejs npm git curl wget perl bash perl-pathtools tar procps nano tini
+RUN        mkdir -p /opt/cronicle \
+        && cd /opt/cronicle \
+        && curl -L https://github.com/jhuckaby/Cronicle/archive/v${CRONICLE_VERSION}.tar.gz | tar zxvf - --strip-components 1 \
+        && npm install \
+        && node bin/build.js dist \
+        && rm -Rf /root/.npm
 
 # Runtime user
 # RUN        adduser cronicle -D -h /opt/cronicle
 # RUN        adduser cronicle docker
 WORKDIR    /opt/cronicle/
-ADD        entrypoint.sh /entrypoint.sh
+ADD        docker/entrypoint.sh /entrypoint.sh
 
 EXPOSE     3012
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,9 +3,10 @@
 ROOT_DIR=/opt/cronicle
 CONF_DIR=$ROOT_DIR/conf
 BIN_DIR=$ROOT_DIR/bin
-LIB_DIR=$ROOT_DIR/lib
 # DATA_DIR needs to be the same as the exposed Docker volume in Dockerfile
 DATA_DIR=$ROOT_DIR/data
+# LOGS_DIR needs to be the same as the exposed Docker volume in Dockerfile
+LOGS_DIR=$ROOT_DIR/logs
 # PLUGINS_DIR needs to be the same as the exposed Docker volume in Dockerfile
 PLUGINS_DIR=$ROOT_DIR/plugins
 
@@ -37,6 +38,13 @@ fi
 
 # Run cronicle with unprivileged user
 # chown -R cronicle:cronicle data/ logs/
+
+# remove old lock file. resolves #9
+PID_FILE=$LOGS_DIR/cronicled.pid
+if [ -f "$PID_FILE" ]; then
+    echo "Removing old PID file: $PID_FILE"
+    rm -f $PID_FILE
+fi
 
 if [ -n "$1" ];
 then


### PR DESCRIPTION
* Update base image. Reduce image size from 398 MB => 148 MB (uncompressed)
* Add environment variable for default text editor. Resolves #8
* Remove /opt/cronicle/logs/cronicled.pid on start. Resolves #9
* Define CRONICLE_VERSION env var
* Move Dockerfile to main folder (good practice)