### PR TITLE
Update cronicle to 0.9.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM       docker:20.10
 LABEL      maintainer="BlueT - Matthew Lien - 練喆明 <bluet@bluet.org>"
 
 # Docker defaults
-ENV        CRONICLE_VERSION 0.9.11
+ENV        CRONICLE_VERSION 0.9.12
 ENV        CRONICLE_base_app_url 'http://localhost:3012'
 ENV        CRONICLE_WebServer__http_port 3012
 ENV        CRONICLE_WebServer__https_port 443

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.9.11
+VERSION=0.9.12
 
 docker build --pull -t bluet/cronicle-docker .
 docker scan bluet/cronicle-docker:latest


### PR DESCRIPTION
Cronicle 0.9.12 has been released recently. It seems that there is no breaking changes.